### PR TITLE
chore: externalize env-dependent config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Base URL for Strapi (used on client and server)
+NEXT_PUBLIC_STRAPI_URL=http://localhost:1337
+
+# Optional server-side Strapi token
+STRAPI_API_TOKEN=
+
+# Resend email credentials
+RESEND_API_KEY=
+RESEND_FROM=onboarding@resend.dev
+RESEND_TO=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,25 +1,18 @@
 import type { NextConfig } from "next";
 
+const STRAPI_URL = process.env.NEXT_PUBLIC_STRAPI_URL || "http://localhost:1337";
+const { protocol, hostname, port } = new URL(STRAPI_URL);
+
+const remotePattern: { protocol: string; hostname: string; port?: string; pathname: string } = {
+  protocol: protocol.replace(":", ""),
+  hostname,
+  pathname: "/uploads/**",
+};
+if (port) remotePattern.port = port;
+
 const nextConfig: NextConfig = {
   images: {
-    remotePatterns: [
-      // Local Strapi (dev)
-      {
-        protocol: "http",
-        hostname: "localhost",
-        port: "1337",
-        pathname: "/uploads/**",
-      },
-      // Add https variant for cases where Strapi is behind HTTPS or deployed
-      {
-        protocol: "https",
-        hostname: "localhost",
-        port: "1337",
-        pathname: "/uploads/**",
-      },
-      // If you later move assets to a CDN or Cloudinary, add it here:
-      // { protocol: "https", hostname: "res.cloudinary.com", pathname: "/**" }
-    ],
+    remotePatterns: [remotePattern],
   },
 };
 


### PR DESCRIPTION
## Summary
- derive remote image pattern from `NEXT_PUBLIC_STRAPI_URL`
- configure email recipient via `RESEND_TO` variable
- add example environment variable file

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Type error: Type '{ params: { slug: string; }; }' does not satisfy the constraint 'PageProps'.)*

------
https://chatgpt.com/codex/tasks/task_e_68ad66721a9c8323a71af641fd577a7c