### PR TITLE
Fix build errors for Next.js 15 build

### DIFF
--- a/app/api/send-email/route.ts
+++ b/app/api/send-email/route.ts
@@ -2,7 +2,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+const resendApiKey = process.env.RESEND_API_KEY;
+const resend = resendApiKey ? new Resend(resendApiKey) : null;
 
 const TO = process.env.RESEND_TO;
 const FROM = process.env.RESEND_FROM || "onboarding@resend.dev";
@@ -141,6 +142,13 @@ export async function POST(req: NextRequest) {
     if (!TO) {
       return NextResponse.json(
         { ok: false, error: "RESEND_TO is not configured." },
+        { status: 500 }
+      );
+    }
+
+    if (!resend) {
+      return NextResponse.json(
+        { ok: false, error: "RESEND_API_KEY is not configured." },
         { status: 500 }
       );
     }

--- a/app/details/[slug]/page.tsx
+++ b/app/details/[slug]/page.tsx
@@ -13,8 +13,12 @@ export async function generateStaticParams() {
 
 export const revalidate = 60;
 
-export default async function DetailsPage({ params }: { params: { slug: string } }) {
-  const { slug } = params;
+export default async function DetailsPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
   const product = await fetchStatueBySlug(slug);
   const relatedProducts = await fetchRandomStatues(3);
 

--- a/app/requests/page.tsx
+++ b/app/requests/page.tsx
@@ -2,9 +2,9 @@
 
 import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
-import { FormEvent, useEffect, useState } from "react";
+import { FormEvent, useEffect, useState, Suspense } from "react";
 
-export default function Requests() {
+function RequestsContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -120,7 +120,7 @@ export default function Requests() {
 
             <label htmlFor="order_details" className="sr-only">Детайли към поръчка</label>
             <textarea
-              className="w-full bg-[#B2886B] text-white font-inter text-[1.2vw] drop-shadow-[0_5px_3px_rgba(0,0,0,0.25)] rounded-lg placeholder:text-[#F4ECE299] py-[1vw] pl-[1.2vw] focus:ring-0 focus:outline-amber-900 resize-none max-xs:text-[3vw] max-xs:py-[2.5vw] max-xs:pl-[4vw]"
+              className="w-full bg-[#B2886B] text-white font-inter text-[1.2vw] drop-shadow-[0_5px_3px_rgба(0,0,0,0.25)] rounded-lg placeholder:text-[#F4ECE299] py-[1vw] pl-[1.2vw] focus:ring-0 focus:outline-amber-900 resize-none max-xs:text-[3vw] max-xs:py-[2.5vw] max-xs:pl-[4vw]"
               rows={3}
               name="order_details"
               id="order_details"
@@ -144,3 +144,12 @@ export default function Requests() {
     </>
   );
 }
+
+export default function Requests() {
+  return (
+    <Suspense fallback={null}>
+      <RequestsContent />
+    </Suspense>
+  );
+}
+

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,11 @@
 import type { NextConfig } from "next";
+import type { RemotePattern } from "next/dist/shared/lib/image-config";
 
 const STRAPI_URL = process.env.NEXT_PUBLIC_STRAPI_URL || "http://localhost:1337";
 const { protocol, hostname, port } = new URL(STRAPI_URL);
 
-const remotePattern: { protocol: string; hostname: string; port?: string; pathname: string } = {
-  protocol: protocol.replace(":", ""),
+const remotePattern: RemotePattern = {
+  protocol: protocol.replace(":", "") as "http" | "https",
   hostname,
   pathname: "/uploads/**",
 };


### PR DESCRIPTION
## Summary
- handle Next.js 15 page params properly in details page
- tighten remote image pattern typing
- avoid Resend API initialization without a key
- wrap requests page in Suspense for `useSearchParams`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad6ebee5088323b92e66b12525566e